### PR TITLE
Attach pulses separately from template optimization

### DIFF
--- a/qiskit_research/utils/__init__.py
+++ b/qiskit_research/utils/__init__.py
@@ -31,6 +31,7 @@ from qiskit_research.utils.pulse_scaling import (
     CombineRuns,
     SECRCalibrationBuilder,
     cr_scaling_passes,
+    pulse_attaching_passes,
 )
 
 __all__ = [

--- a/qiskit_research/utils/convenience.py
+++ b/qiskit_research/utils/convenience.py
@@ -26,6 +26,7 @@ from qiskit_research.utils import (
     PauliTwirl,
     dynamical_decoupling_passes,
     cr_scaling_passes,
+    pulse_attaching_passes,
     add_pulse_calibrations,
 )
 
@@ -96,6 +97,27 @@ def scale_cr_pulses(
         list(
             cr_scaling_passes(
                 inst_sched_map, channel_map, templates, param_bind=param_bind
+            )
+        )
+    )
+    return pass_manager.run(circuits)
+
+def attach_cr_pulses(
+    circuits: Union[QuantumCircuit, List[QuantumCircuit]],
+    backend: Backend,
+    param_bind: dict,
+) -> Union[QuantumCircuit, List[QuantumCircuit]]:
+    """
+    Scale circuits using Pulse scaling technique from
+    http://arxiv.org/abs/2012.11660
+    """
+    inst_sched_map = backend.defaults().instruction_schedule_map
+    channel_map = backend.configuration().qubit_channel_mapping
+
+    pass_manager = PassManager(
+        list(
+            pulse_attaching_passes(
+                inst_sched_map, channel_map, param_bind
             )
         )
     )

--- a/qiskit_research/utils/pulse_scaling.py
+++ b/qiskit_research/utils/pulse_scaling.py
@@ -335,3 +335,14 @@ def cr_scaling_passes(
         yield Optimize1qGatesDecomposition(BASIS_GATES)
         yield CXCancellation()
         yield SECRCalibrationBuilder(inst_sched_map, channel_map)
+
+def pulse_attaching_passes(
+    inst_sched_map: InstructionScheduleMap,
+    channel_map: List[List[str]],
+    param_bind: dict,
+) -> Iterable[BasePass]:
+    """Yields transpilation passes for attaching pulse schedules."""
+    yield BindParameters(param_bind)
+    yield Optimize1qGatesDecomposition(BASIS_GATES)
+    yield CXCancellation()
+    yield SECRCalibrationBuilder(inst_sched_map, channel_map)

--- a/qiskit_research/utils/pulse_scaling.py
+++ b/qiskit_research/utils/pulse_scaling.py
@@ -331,6 +331,8 @@ def cr_scaling_passes(
     yield CXCancellation()
     yield CombineRuns(["rz"])
     if param_bind is not None:
+        # can probably replace the lines below with
+        # pulse_attaching_passes(inst_sched_map, channel_map, param_bind)
         yield BindParameters(param_bind)
         yield Optimize1qGatesDecomposition(BASIS_GATES)
         yield CXCancellation()


### PR DESCRIPTION
Separated pulse attaching transpiler passes to method `pulse_attaching_passes` and a convenience method `attach_cr_pulses` to run those transpiler passes. Because template optimization is a greedy algorithm, some situations benefit from running it on a smaller subcircuit and then building the full circuit from the optimized subcircuit, then attaching the pulse gates from the `RZXCalibrationBuilder`.