### PR TITLE
fix pulse calibrations

### DIFF
--- a/test/utils/test_dynamical_decoupling.py
+++ b/test/utils/test_dynamical_decoupling.py
@@ -15,7 +15,10 @@
 from qiskit import transpile
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers.fake_provider import FakeWashington
-from qiskit_research.utils.convenience import add_dynamical_decoupling
+from qiskit_research.utils.convenience import (
+    add_dynamical_decoupling,
+    add_pulse_calibrations,
+)
 
 
 def test_add_dynamical_decoupling():
@@ -33,3 +36,20 @@ def test_add_dynamical_decoupling():
         transpiled, backend, "XY4pm", add_pulse_cals=True
     )
     assert isinstance(transpiled_dd, QuantumCircuit)
+
+
+def test_add_pulse_calibrations():
+    """Test adding dynamical decoupling."""
+    circuit = QuantumCircuit(2)
+    backend = FakeWashington()
+    add_pulse_calibrations(circuit, backend)
+    for key in circuit.calibrations["xp"]:
+        drag_xp = (
+            circuit.calibrations["xp"][key]
+            .instructions[0][1]
+            .operands[0]
+            .instructions[0][1]
+            .operands[0]
+        )
+        drag_xm = circuit.calibrations["xm"][key].instructions[0][1].operands[0]
+        assert drag_xm.amp == -drag_xp.amp


### PR DESCRIPTION
When Drag was made into a SymbolicPulse, the calibrations broke. This PR adds tests to check that the calibrations for Xp and Xm are correct.