### PR TITLE
trim unrelated passes from cr_scaling_passes

### DIFF
--- a/qiskit_research/utils/pulse_scaling.py
+++ b/qiskit_research/utils/pulse_scaling.py
@@ -421,9 +421,6 @@ def cr_scaling_passes(
         yield ForceZZTemplateSubstitution()  # workaround for Terra Issue
     if unroll_rzx_to_ecr:
         yield RZXtoEchoedCR(backend)
-    yield Optimize1qGatesDecomposition(BASIS_GATES)
-    yield CXCancellation()
-    yield CombineRuns(["rz"])
     if param_bind is not None:
         yield from pulse_attaching_passes(backend, param_bind)
 


### PR DESCRIPTION
The function `cr_scaling_passes` should only yield passes for pulse scaling and not unrelated ones such as passes for gate optimization. The user may already be running those in a different transpilation stage.