### PR TITLE
add note to cost func

### DIFF
--- a/qiskit_research/utils/cost_funcs.py
+++ b/qiskit_research/utils/cost_funcs.py
@@ -37,8 +37,9 @@ def cost_func_scaled_cr(
         float: error
 
     Note:
-    For a transpiled circuit which uses less qubit than the available ones on the target device,
-    there may be a surplus of matching layouts which differ only by permutations of the unused qubits.
+    For a transpiled circuit which uses less qubit than the available ones on the 
+    target device, there may be a surplus of matching layouts which differ only by 
+    permutations of the unused qubits.
     """
     out = []
     props = backend.properties()

--- a/qiskit_research/utils/cost_funcs.py
+++ b/qiskit_research/utils/cost_funcs.py
@@ -35,6 +35,10 @@ def cost_func_scaled_cr(
 
     Returns:
         float: error
+
+    Note:
+    For a transpiled circuit which uses less qubit than the available ones on the target device,
+    there may be a surplus of matching layouts which differ only by permutations of the unused qubits.
     """
     out = []
     props = backend.properties()

--- a/qiskit_research/utils/cost_funcs.py
+++ b/qiskit_research/utils/cost_funcs.py
@@ -22,9 +22,8 @@ from qiskit.qasm import pi
 
 def cost_func_scaled_cr(
     circ: QuantumCircuit,
-    layouts: list[list[int]],
     backend: Backend,
-) -> list[tuple[list[int], float]]:
+) -> float:
     """
     A custom cost function that includes T1 and T2 computed during idle periods,
     for an already transpiled and scheduled circuit circ
@@ -35,13 +34,7 @@ def cost_func_scaled_cr(
 
     Returns:
         float: error
-
-    Note:
-        For a transpiled circuit which uses less qubit than the available ones on the 
-        target device, there may be a surplus of matching layouts which differ only by 
-        permutations of the unused qubits.
     """
-    out = []
     props = backend.properties()
     dt = backend.configuration().dt
     num_qubits = backend.configuration().num_qubits
@@ -51,69 +44,67 @@ def cost_func_scaled_cr(
     error = 0.0
     fid = 1.0
     touched = set()
-    for layout in layouts:
-        for item in circ.data:
-            if item[0].name == "cx":
-                q0 = circ.find_bit(item[1][0]).index
-                q1 = circ.find_bit(item[1][1]).index
-                fid *= 1 - props.gate_error("cx", [q0, q1])
-                touched.add(q0)
-                touched.add(q1)
+    for item in circ.data:
+        if item[0].name == "cx":
+            q0 = circ.find_bit(item[1][0]).index
+            q1 = circ.find_bit(item[1][1]).index
+            fid *= 1 - props.gate_error("cx", [q0, q1])
+            touched.add(q0)
+            touched.add(q1)
 
-            # if it is a scaled pulse derived from cx
-            elif item[0].name == "rzx":
-                q0 = circ.find_bit(item[1][0]).index
-                q1 = circ.find_bit(item[1][1]).index
+        # if it is a scaled pulse derived from cx
+        elif item[0].name == "rzx":
+            q0 = circ.find_bit(item[1][0]).index
+            q1 = circ.find_bit(item[1][1]).index
 
-                cr_error = np.abs(
-                    float(item[0].params[0]) / (pi / 2)
-                ) * props.gate_error("cx", [q0, q1])
+            cr_error = np.abs(
+                float(item[0].params[0]) / (pi / 2)
+            ) * props.gate_error("cx", [q0, q1])
 
-                # assumes control qubit is actually control for cr
-                echo_error = props.gate_error("x", q0)
+            # assumes control qubit is actually control for cr
+            echo_error = props.gate_error("x", q0)
 
-                fid *= 1 - max(cr_error, 2 * echo_error)
-            elif item[0].name == "secr":
-                q0 = circ.find_bit(item[1][0]).index
-                q1 = circ.find_bit(item[1][1]).index
+            fid *= 1 - max(cr_error, 2 * echo_error)
+        elif item[0].name == "secr":
+            q0 = circ.find_bit(item[1][0]).index
+            q1 = circ.find_bit(item[1][1]).index
 
-                cr_error = np.abs(
-                    (float(item[0].params[0])) / (pi / 2)
-                ) * props.gate_error("cx", [q0, q1])
+            cr_error = np.abs(
+                (float(item[0].params[0])) / (pi / 2)
+            ) * props.gate_error("cx", [q0, q1])
 
-                # assumes control qubit is actually control for cr
-                echo_error = props.gate_error("x", q0)
+            # assumes control qubit is actually control for cr
+            echo_error = props.gate_error("x", q0)
 
-                fid *= 1 - max(cr_error, echo_error)
+            fid *= 1 - max(cr_error, echo_error)
 
-            elif item[0].name in ["sx", "x"]:
-                q0 = circ.find_bit(item[1][0]).index
-                fid *= 1 - props.gate_error(item[0].name, q0)
-                touched.add(q0)
+        elif item[0].name in ["sx", "x"]:
+            q0 = circ.find_bit(item[1][0]).index
+            fid *= 1 - props.gate_error(item[0].name, q0)
+            touched.add(q0)
 
-            # if it is a dynamical decoupling pulse
-            elif item[0].name in ["xp", "xm", "y", "yp", "ym"]:
-                q0 = circ.find_bit(item[1][0]).index
-                fid *= 1 - props.gate_error("x", q0)
-                touched.add(q0)
+        # if it is a dynamical decoupling pulse
+        elif item[0].name in ["xp", "xm", "y", "yp", "ym"]:
+            q0 = circ.find_bit(item[1][0]).index
+            fid *= 1 - props.gate_error("x", q0)
+            touched.add(q0)
 
-            elif item[0].name == "measure":
-                q0 = circ.find_bit(item[1][0]).index
-                fid *= 1 - props.readout_error(q0)
-                touched.add(q0)
+        elif item[0].name == "measure":
+            q0 = circ.find_bit(item[1][0]).index
+            fid *= 1 - props.readout_error(q0)
+            touched.add(q0)
 
-            elif item[0].name == "delay":
-                q0 = circ.find_bit(item[1][0]).index
-                # Ignore delays that occur before gates
-                # This assumes you are in ground state and errors
-                # do not occur.
-                if q0 in touched:
-                    time = item[0].duration * dt
-                    fid *= 1 - idle_error(time, t1s[q0], t2s[q0])
+        elif item[0].name == "delay":
+            q0 = circ.find_bit(item[1][0]).index
+            # Ignore delays that occur before gates
+            # This assumes you are in ground state and errors
+            # do not occur.
+            if q0 in touched:
+                time = item[0].duration * dt
+                fid *= 1 - idle_error(time, t1s[q0], t2s[q0])
 
-        error = 1 - fid
-        out.append((layout, error))
-    return out
+    error = 1 - fid
+    return error
 
 
 def idle_error(time, t1, t2):

--- a/qiskit_research/utils/cost_funcs.py
+++ b/qiskit_research/utils/cost_funcs.py
@@ -37,9 +37,9 @@ def cost_func_scaled_cr(
         float: error
 
     Note:
-    For a transpiled circuit which uses less qubit than the available ones on the 
-    target device, there may be a surplus of matching layouts which differ only by 
-    permutations of the unused qubits.
+        For a transpiled circuit which uses less qubit than the available ones on the 
+        target device, there may be a surplus of matching layouts which differ only by 
+        permutations of the unused qubits.
     """
     out = []
     props = backend.properties()


### PR DESCRIPTION
Adding a note to the `cost_func_scaled_cr` function in the `cost_funcs` module to help clarify the best usage of the fiunction. In particular, if matching layouts are searched for a transpiled circuit with less active qubits than the number of available qubits in the backend, layouts containing all possible permutations of unused qubits will be included. User must be careful that an exponential number of layouts is not retrieved when directly using transpiled circuits instead of deflated ones.